### PR TITLE
For V1.1: Customisable Send Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 An app to automatically send the GA declaration form every week at a specified time, for the subscribed users.
 
+## ⭐️ NEW! Features (V1.1) 11 March, 2021 
+
+- Allow user to configure the day they want their all-clear forms sent.
+
+## Features (V1.0)
+
+- Students and GA team can send all-clear declaration forms every week.
+
+## Features in Consideration
+- Allow users to customise form fields (so these will be forms that are not all-clear)
+- Notify user via email for every declaration submitted? (Users should be able to turn on/off the feature. Or they can enable emails only when the service fails.)
+
+---
+
+## For Developers:
+
 ## Notable Technologies: Backend
 
 - Express
@@ -48,21 +64,6 @@ For `api` you can use `yarn dev` if you have `nodemon` installed, if not `yarn s
 
 For client, just `yarn start`
 
-## Features
-
-✅ Setup frontend for basic authentication & CRUD (without sessions/cookies/JWT)
-
-✅ Setup backend for CRUD (is delete necessary?)
-
-✅ Setup backend to send forms periodically
-
-✅ Validation for frontend input
-
-✅ Users can choose cohort name
-
-✅ Add compatibility for Team declaration forms
-
-❗️ Notify user via email for every declaration submitted? (Users should be able to turn on/off the feature. Or they can enable emails only when the service fails.)
 
 ## Known Issues
 

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -138,7 +138,7 @@ const controllers = {
       user_type,
       send_day,
     } = req.body
-    User.findOneAndUpdate(
+    User.updateOne(
       { email },
       { ga_email, full_name, active, mobile, cohort, user_type, send_day },
       { new: true }, // returns the updated document

--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -56,6 +56,7 @@ const controllers = {
         last_declared,
         cohort,
         user_type,
+        send_day,
       } = newUser
       let userDataToSend = {
         ga_email,
@@ -66,6 +67,7 @@ const controllers = {
         last_declared,
         cohort,
         user_type,
+        send_day,
       }
       setResponse(res, false, 'User was created successfully.', userDataToSend)
     } catch (err) {
@@ -90,6 +92,7 @@ const controllers = {
           last_declared,
           cohort,
           user_type,
+          send_day,
         } = user
         setResponse(res, false, 'Login successful.', {
           email: user.email,
@@ -100,6 +103,7 @@ const controllers = {
           last_declared,
           cohort,
           user_type,
+          send_day,
         })
       } else {
         setResponse(res, true, 'Password is incorrect.')
@@ -132,10 +136,11 @@ const controllers = {
       mobile,
       cohort,
       user_type,
+      send_day,
     } = req.body
     User.findOneAndUpdate(
       { email },
-      { ga_email, full_name, active, mobile, cohort, user_type },
+      { ga_email, full_name, active, mobile, cohort, user_type, send_day },
       { new: true }, // returns the updated document
     )
       .then((updatedUser) => {
@@ -148,6 +153,7 @@ const controllers = {
           last_declared: updatedUser.last_declared,
           cohort: updatedUser.cohort,
           user_type: updatedUser.user_type,
+          send_day: updatedUser.send_day,
         }
         setResponse(res, false, 'Update was successful.', userDataToSend)
       })

--- a/api/jobs/sendGoogleForms.js
+++ b/api/jobs/sendGoogleForms.js
@@ -10,15 +10,9 @@ const dayOfWeekAsString = require('./modules/dayOfWeekAsString')
 
 const sendGoogleForms = async () => {
   const dayOfWeekAsIndex = new Date().getDay().toString()
-  console.log(
-    `The app should run tasks every ${dayOfWeekAsString(SCHEDULED_DAY)}.`,
-  )
+  const currentDayString = dayOfWeekAsString(dayOfWeekAsIndex);
   console.log(`Today is ${dayOfWeekAsString(dayOfWeekAsIndex)}.`)
-  if (dayOfWeekAsIndex !== SCHEDULED_DAY) {
-    console.log(`We are not scheduled to send a form today.`)
-    return
-  }
-  const activeUsers = await UserModel.find({ active: true })
+  const activeUsers = await UserModel.find({ active: true, send_day: currentDayString })
   const allPostRequests = activeUsers.map((user) => {
     // Create the post request to submit the form for each active user.
     return CreatePostRequest(

--- a/api/jobs/sendGoogleForms.js
+++ b/api/jobs/sendGoogleForms.js
@@ -17,6 +17,9 @@ const sendGoogleForms = async () => {
 
   if (currentDay == scheduledDay) {
     // If it's the scheduled day, we send it for users who have no configured send_day, or whose send_day is the scheduled day.
+    console.log(
+      `It is the scheduled day. Sending for users whose send_day is ${scheduledDay} or N/A.`,
+    )
     usersToSend = await UserModel.find({
       active: true,
       send_day: { $in: ['', scheduledDay] },

--- a/api/jobs/sendGoogleForms.js
+++ b/api/jobs/sendGoogleForms.js
@@ -5,27 +5,27 @@ const CreatePostRequest = require('./modules/createPostRequest')
 const callRequestInBatches = require('./modules/callRequestInBatches')
 const connectToDBAndRun = require('./modules/connectToDBAndRun')
 const UserModel = require('../models/user')
-// const ENVIRONMENT = ENV.NODE_ENV;
 const dayOfWeekAsString = require('./modules/dayOfWeekAsString')
 
 const sendGoogleForms = async () => {
-  const dayOfWeekAsIndex = new Date().getDay().toString()
-  const currentDayString = dayOfWeekAsString(dayOfWeekAsIndex)
-  console.log(`Today is ${dayOfWeekAsString(dayOfWeekAsIndex)}.`)
+  const dayOfWeekIndex = new Date().getDay().toString()
+  const currentDay = dayOfWeekAsString(dayOfWeekIndex)
+  const scheduledDay = dayOfWeekAsString(SCHEDULED_DAY)
+  console.log(`Today is ${currentDay}.`)
 
   let usersToSend
 
-  if (currentDayString == SCHEDULED_DAY) {
+  if (currentDay == scheduledDay) {
     // If it's the scheduled day, we send it for users who have no configured send_day, or whose send_day is the scheduled day.
-    usersToSend = UserModel.find({
+    usersToSend = await UserModel.find({
       active: true,
-      send_day: { $in: [null, SCHEDULED_DAY] },
+      send_day: { $in: ['', scheduledDay] },
     })
   } else {
     // If it's a non-scheduled day, we send it for users who have customised their send_day to the current day.
     usersToSend = await UserModel.find({
       active: true,
-      send_day: currentDayString,
+      send_day: currentDay,
     })
   }
 

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -20,7 +20,7 @@ const userSchema = new mongoose.Schema({
     required: true,
     default: Date.now,
   },
-  send_day: { type: String, required: true }
+  send_day: { type: String },
 })
 
 const UserModel = mongoose.model('User', userSchema)

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -20,6 +20,7 @@ const userSchema = new mongoose.Schema({
     required: true,
     default: Date.now,
   },
+  send_day: { type: String, required: true }
 })
 
 const UserModel = mongoose.model('User', userSchema)

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -20,7 +20,20 @@ const userSchema = new mongoose.Schema({
     required: true,
     default: Date.now,
   },
-  send_day: { type: String },
+  send_day: {
+    type: String,
+    enum: [
+      '',
+      'Monday',
+      'Tuesday',
+      'Wednesday',
+      'Thursday',
+      'Friday',
+      'Saturday',
+      'Sunday',
+    ],
+    default: '',
+  },
 })
 
 const UserModel = mongoose.model('User', userSchema)

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#000000" />
     <meta
       name="description"
-      content="Web site created using create-react-app"
+      content="Helps you with GA declaration forms every week."
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -203,6 +203,22 @@ export default function App() {
       })
   }
 
+  const { getScheduledTime } = requests
+  const [loadingScheduledTime, setLoadingScheduledTime] = useState(true)
+  const [scheduledTime, setScheduledTime] = useState('')
+  useEffect(() => {
+    getScheduledTime()
+      .then(({ data }) => {
+        setScheduledTime(data)
+        setLoadingScheduledTime(false)
+      })
+      .catch((err) => {
+        console.error(err)
+        setLoadingScheduledTime(false)
+        setScheduledTime('Error getting scheduled time from server.')
+      })
+  }, [])
+
   /*
   Everytime input is changed, and the user is either authenticated or has updated their profile, check if the inputs differ from their user data.
   If it differs, we consider the profile to have changed. This will enable the update button.
@@ -257,11 +273,15 @@ export default function App() {
             inputs={inputs}
             user={user}
             buttonText={buttonText}
+            scheduledTime={scheduledTime}
             constants={{ AUTHENTICATED, CHECK_EMAIL, UPDATED_TEXT, UPDATED }}
           />
 
           <Box mt={5}>
-            <Welcome />
+            <Welcome
+              loadingScheduledTime={loadingScheduledTime}
+              scheduledTime={scheduledTime}
+            />
             <Copyright />
           </Box>
         </div>

--- a/client/src/App.js
+++ b/client/src/App.js
@@ -162,7 +162,10 @@ export default function App() {
   }
 
   const updateUser = () => {
-    const form = formValidator('ga_email, mobile, full_name, cohort', inputs)
+    const form = formValidator(
+      'ga_email, mobile, full_name, cohort, user_type, send_day',
+      inputs,
+    )
     setErrors((prev) => ({ ...prev, ...form.errors }))
     if (!form.isValid) return
     setLoading(true)
@@ -181,7 +184,7 @@ export default function App() {
 
   const registerUser = () => {
     const form = formValidator(
-      'ga_email, password, mobile, full_name, cohort',
+      'ga_email, password, mobile, full_name, cohort, user_type, send_day',
       inputs,
     )
     setErrors((prev) => ({ ...prev, ...form.errors }))

--- a/client/src/components/Welcome.js
+++ b/client/src/components/Welcome.js
@@ -1,24 +1,7 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import { Typography, Box, Link, CircularProgress } from '@material-ui/core'
-import requests from '../helpers/api'
 
-export default function Welcome() {
-  const { getScheduledTime } = requests
-  const [loadingScheduledTime, setLoadingScheduledTime] = useState(true)
-  const [scheduledTime, setScheduledTime] = useState('')
-  useEffect(() => {
-    getScheduledTime()
-      .then(({ data }) => {
-        setScheduledTime(data)
-        setLoadingScheduledTime(false)
-      })
-      .catch((err) => {
-        console.error(err)
-        setLoadingScheduledTime(false)
-        setScheduledTime('Error getting scheduled time from server.')
-      })
-  }, [])
-
+export default function Welcome({ loadingScheduledTime, scheduledTime }) {
   return (
     <div>
       <Box mb={2}>

--- a/client/src/components/form/Form.js
+++ b/client/src/components/form/Form.js
@@ -27,6 +27,7 @@ export default function Form({
   checkIfUserExists,
   registerUser,
   buttonText,
+  scheduledTime,
 }) {
   const renderErrors = (arrayOfMessages) => {
     return arrayOfMessages.map((msg, index) => {
@@ -76,6 +77,7 @@ export default function Form({
           classes={classes}
           renderErrors={renderErrors}
           handleInputChange={(e) => handleInputChange(e)}
+          scheduledTime={scheduledTime}
         />
       )}
 

--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -16,6 +16,7 @@ export default function Register({
   errors,
   renderErrors,
   classes,
+  scheduledTime,
 }) {
   const { getCohortList } = requests
   const [cohorts, setCohorts] = useState(['SEIF 3'])
@@ -52,7 +53,6 @@ export default function Register({
     full_name: fullNameErrors,
     cohort: cohortErrors,
     user_type: userTypeErrors,
-    send_day: sendDayErrors,
   } = errors
   return (
     <div>
@@ -177,12 +177,9 @@ export default function Register({
           <FormHelperText>{renderErrors(userTypeErrors)}</FormHelperText>
         )}
       </FormControl>
-      <FormControl
-        className={classes.formControl}
-        error={sendDayErrors.length > 0}
-      >
+      <FormControl className={classes.formControl}>
         <InputLabel shrink id="user_sendDay">
-          Day to Send
+          Day to Send (Optional: If empty, we'll send it every {scheduledTime}.)
         </InputLabel>{' '}
         <Select
           labelId="send_dayLabel"
@@ -197,9 +194,6 @@ export default function Register({
         >
           {dayOptions}
         </Select>
-        {sendDayErrors.length > 0 && (
-          <FormHelperText>{renderErrors(sendDayErrors)}</FormHelperText>
-        )}
       </FormControl>
     </div>
   )

--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -180,7 +180,8 @@ export default function Register({
       </FormControl>
       <FormControl className={classes.formControl}>
         <InputLabel shrink id="user_sendDay">
-          Day to Send (Optional: If empty, we'll send it every {scheduledTime}.)
+          Day to Send (Optional: If set to N/A, we'll send it every{' '}
+          {scheduledTime}.)
         </InputLabel>{' '}
         <Select
           labelId="send_dayLabel"

--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -54,6 +54,7 @@ export default function Register({
     cohort: cohortErrors,
     user_type: userTypeErrors,
   } = errors
+
   return (
     <div>
       <TextField
@@ -185,13 +186,14 @@ export default function Register({
           labelId="send_dayLabel"
           id="send_day"
           className={classes.selectEmpty}
-          displayEmpty
           fullWidth
           name="send_day"
           value={inputs.send_day}
           placeholder="Send Day"
           onChange={(e) => handleInputChange(e)}
+          displayEmpty
         >
+          <MenuItem value="">N/A: Defaults to {scheduledTime}</MenuItem>
           {dayOptions}
         </Select>
       </FormControl>

--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -8,6 +8,7 @@ import {
   FormHelperText,
 } from '@material-ui/core'
 import requests from '../../helpers/api'
+import { DAY } from '../../constants'
 
 export default function Register({
   inputs,
@@ -37,12 +38,21 @@ export default function Register({
       })
   }, [])
 
+  const dayOptions = Object.entries(DAY).map((k) => {
+    return (
+      <MenuItem key={k[0]} value={k[1]}>
+        {k[1]}
+      </MenuItem>
+    )
+  })
+
   const {
     ga_email: GAEmailErrors,
     mobile: mobileErrors,
     full_name: fullNameErrors,
     cohort: cohortErrors,
     user_type: userTypeErrors,
+    send_day: sendDayErrors,
   } = errors
   return (
     <div>
@@ -150,14 +160,12 @@ export default function Register({
           User Type
         </InputLabel>{' '}
         <Select
-          // variant="outlined"
           labelId="user_typeLabel"
           id="user_type"
           className={classes.selectEmpty}
           displayEmpty
           fullWidth
           name="user_type"
-          // label="cohort name"
           value={inputs.user_type}
           placeholder="User Type"
           onChange={(e) => handleInputChange(e)}
@@ -167,6 +175,30 @@ export default function Register({
         </Select>
         {userTypeErrors.length > 0 && (
           <FormHelperText>{renderErrors(userTypeErrors)}</FormHelperText>
+        )}
+      </FormControl>
+      <FormControl
+        className={classes.formControl}
+        error={sendDayErrors.length > 0}
+      >
+        <InputLabel shrink id="user_sendDay">
+          Day to Send
+        </InputLabel>{' '}
+        <Select
+          labelId="send_dayLabel"
+          id="send_day"
+          className={classes.selectEmpty}
+          displayEmpty
+          fullWidth
+          name="send_day"
+          value={inputs.send_day}
+          placeholder="Send Day"
+          onChange={(e) => handleInputChange(e)}
+        >
+          {dayOptions}
+        </Select>
+        {sendDayErrors.length > 0 && (
+          <FormHelperText>{renderErrors(sendDayErrors)}</FormHelperText>
         )}
       </FormControl>
     </div>

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -6,11 +6,11 @@ export const LOGIN = 'login'
 export const REGISTER = 'register'
 export const API_URL = process.env.REACT_APP_API_URL
 export const DAY = {
-    MON: "Monday",
-    TUE: "Tuesday",
-    WED: "Wednesday",
-    THU: "Thursday",
-    FRI: "Friday",
-    SAT: "Saturday",
-    SUN: "Sunday"
+  MON: 'Monday',
+  TUE: 'Tuesday',
+  WED: 'Wednesday',
+  THU: 'Thursday',
+  FRI: 'Friday',
+  SAT: 'Saturday',
+  SUN: 'Sunday',
 }

--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -5,3 +5,12 @@ export const UPDATED = 'updated profile'
 export const LOGIN = 'login'
 export const REGISTER = 'register'
 export const API_URL = process.env.REACT_APP_API_URL
+export const DAY = {
+    MON: "Monday",
+    TUE: "Tuesday",
+    WED: "Wednesday",
+    THU: "Thursday",
+    FRI: "Friday",
+    SAT: "Saturday",
+    SUN: "Sunday"
+}

--- a/client/src/helpers/api.js
+++ b/client/src/helpers/api.js
@@ -21,6 +21,7 @@ const requests = {
     mobile,
     cohort,
     user_type,
+    send_day,
   }) => {
     return axios.post(`${API_URL}/register`, {
       email,
@@ -30,6 +31,7 @@ const requests = {
       mobile,
       cohort,
       user_type,
+      send_day,
     })
   },
 
@@ -41,6 +43,7 @@ const requests = {
     mobile,
     cohort,
     user_type,
+    send_day,
   }) => {
     return axios.patch(`${API_URL}/update`, {
       email,
@@ -50,6 +53,7 @@ const requests = {
       mobile,
       cohort,
       user_type,
+      send_day,
     })
   },
 

--- a/client/src/helpers/validator.js
+++ b/client/src/helpers/validator.js
@@ -76,14 +76,14 @@ export default function formValidator(inputTypes, inputs) {
       }
     }
 
-    if (type === 'send_day') {
-      const { send_day } = inputs
-      errors.send_day = []
-      if (send_day === '') {
-        errors.send_day.push('Please select a day to send your declaration.')
-        isValid = false
-      }
-    }
+    // if (type === 'send_day') {
+    //   const { send_day } = inputs
+    //   errors.send_day = []
+    //   if (send_day === '') {
+    //     errors.send_day.push('Please select a day to send your declaration.')
+    //     isValid = false
+    //   }
+    // }
   })
 
   return { isValid, errors }

--- a/client/src/helpers/validator.js
+++ b/client/src/helpers/validator.js
@@ -1,6 +1,5 @@
 export default function formValidator(inputTypes, inputs) {
   const types = inputTypes.split(', ')
-  // console.log(`Validating ${types}`);
   const errors = {}
   let isValid = true
   types.forEach((type) => {
@@ -65,6 +64,23 @@ export default function formValidator(inputTypes, inputs) {
       errors.cohort = []
       if (cohort === '') {
         errors.cohort.push('Please select a cohort.')
+        isValid = false
+      }
+    }
+    if (type === 'user_type') {
+      const { user_type } = inputs
+      errors.user_type = []
+      if (user_type === '') {
+        errors.user_type.push('Please select a cohort.')
+        isValid = false
+      }
+    }
+
+    if (type === 'send_day') {
+      const { send_day } = inputs
+      errors.send_day = []
+      if (send_day === '') {
+        errors.send_day.push('Please select a day to send your declaration.')
         isValid = false
       }
     }

--- a/client/src/helpers/validator.js
+++ b/client/src/helpers/validator.js
@@ -71,7 +71,7 @@ export default function formValidator(inputTypes, inputs) {
       const { user_type } = inputs
       errors.user_type = []
       if (user_type === '') {
-        errors.user_type.push('Please select a cohort.')
+        errors.user_type.push('Please select the user type.')
         isValid = false
       }
     }

--- a/client/src/states/defaultStates.js
+++ b/client/src/states/defaultStates.js
@@ -10,6 +10,7 @@ const defaultStates = {
     mobile: '',
     cohort: '',
     user_type: '',
+    send_day: '',
   },
   message:
     'If you are registered, you will be prompted to login. If not, you will be prompted to register.',
@@ -22,6 +23,7 @@ const defaultStates = {
     password: [],
     cohort: [],
     user_type: [],
+    send_day: [],
   },
   buttonText: CHECK_EMAIL,
   user: { email: '' },


### PR DESCRIPTION
This PR will allow users to customise which day they want their declarations sent.

If left empty, it will be sent on the API's configured scheduled day.

Also fixes the lack of validation for user_type.