### PR TITLE
Remove autofocus on GA Email

### DIFF
--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -68,7 +68,6 @@ export default function Register({
         label="GA Email Address"
         name="ga_email"
         // autoComplete="email"
-        autoFocus
         value={inputs.ga_email}
         onChange={(e) => handleInputChange(e)}
       />


### PR DESCRIPTION
The form autofocuses to the GA email during registration/update, which looks a bit confusing. This removes autofocus from the form entirely.