### PR TITLE
Make cohorts optional for GA team users

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -43,6 +43,9 @@ const controllers = {
       errorHandler(res, err, 'There was an unexpected system error.')
     }
 
+    // Removes the cohort field if it's a GA Team user.
+    if (req.body.user_type === 'team') req.body.cohort = ''
+
     try {
       const newUser = await User.create({ ...req.body, password: argon2Hash })
 
@@ -138,6 +141,10 @@ const controllers = {
       user_type,
       send_day,
     } = req.body
+
+    // Removes the cohort field if it's a GA Team user.
+    if (user_type === 'team') cohort = ''
+
     User.updateOne(
       { email },
       { ga_email, full_name, active, mobile, cohort, user_type, send_day },

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -6,7 +6,7 @@ const userSchema = new mongoose.Schema({
   ga_email: { type: String, required: true },
   active: { type: Boolean, default: true }, // determines if server will automatically send requests,
   mobile: { type: String, required: true },
-  cohort: { type: String, required: true },
+  cohort: { type: String, default: '' },
   user_type: { type: String, enum: ['student', 'team'], required: true },
   last_declared: Date,
   password: { type: String, required: true },

--- a/client/src/components/form/Register.js
+++ b/client/src/components/form/Register.js
@@ -129,30 +129,7 @@ export default function Register({
         value={inputs.full_name}
         onChange={(e) => handleInputChange(e)}
       />
-      <FormControl
-        className={classes.formControl}
-        error={cohortErrors.length > 0}
-      >
-        <InputLabel shrink id="cohortLabel">
-          Cohort Name
-        </InputLabel>{' '}
-        <Select
-          labelId="cohortLabel"
-          id="cohort"
-          className={classes.selectEmpty}
-          displayEmpty
-          fullWidth
-          name="cohort"
-          value={inputs.cohort}
-          placeholder="Cohort Name"
-          onChange={(e) => handleInputChange(e)}
-        >
-          {cohortItems}
-        </Select>
-        {cohortErrors.length > 0 && (
-          <FormHelperText>{renderErrors(cohortErrors)}</FormHelperText>
-        )}
-      </FormControl>
+
       <FormControl
         className={classes.formControl}
         error={userTypeErrors.length > 0}
@@ -178,6 +155,34 @@ export default function Register({
           <FormHelperText>{renderErrors(userTypeErrors)}</FormHelperText>
         )}
       </FormControl>
+
+      {inputs.user_type === 'student' && (
+        <FormControl
+          className={classes.formControl}
+          error={cohortErrors.length > 0}
+        >
+          <InputLabel shrink id="cohortLabel">
+            Cohort Name
+          </InputLabel>{' '}
+          <Select
+            labelId="cohortLabel"
+            id="cohort"
+            className={classes.selectEmpty}
+            displayEmpty
+            fullWidth
+            name="cohort"
+            value={inputs.cohort}
+            placeholder="Cohort Name"
+            onChange={(e) => handleInputChange(e)}
+          >
+            {cohortItems}
+          </Select>
+          {cohortErrors.length > 0 && (
+            <FormHelperText>{renderErrors(cohortErrors)}</FormHelperText>
+          )}
+        </FormControl>
+      )}
+
       <FormControl className={classes.formControl}>
         <InputLabel shrink id="user_sendDay">
           Day to Send (Optional: If set to N/A, we'll send it every{' '}

--- a/client/src/helpers/validator.js
+++ b/client/src/helpers/validator.js
@@ -1,5 +1,6 @@
 export default function formValidator(inputTypes, inputs) {
   const types = inputTypes.split(', ')
+  console.log(types)
   const errors = {}
   let isValid = true
   types.forEach((type) => {
@@ -60,9 +61,9 @@ export default function formValidator(inputTypes, inputs) {
       }
     }
     if (type === 'cohort') {
-      const { cohort } = inputs
+      const { cohort, user_type } = inputs
       errors.cohort = []
-      if (cohort === '') {
+      if (cohort === '' && user_type === 'student') {
         errors.cohort.push('Please select a cohort.')
         isValid = false
       }


### PR DESCRIPTION
Cohorts are not a required field for GA team declaration form. This PR makes the `cohort` field optional, where it was originally required. It will also clear the `cohort` field in the database when `user_type` is `team`.